### PR TITLE
Fix hsm unallocated mem usage

### DIFF
--- a/lib/sbi/sbi_init.c
+++ b/lib/sbi/sbi_init.c
@@ -346,10 +346,6 @@ static void init_warm_startup(struct sbi_scratch *scratch, u32 hartid)
 	if (!init_count_offset)
 		sbi_hart_hang();
 
-	rc = sbi_hsm_init(scratch, hartid, FALSE);
-	if (rc)
-		sbi_hart_hang();
-
 	rc = sbi_platform_early_init(plat, FALSE);
 	if (rc)
 		sbi_hart_hang();
@@ -404,8 +400,13 @@ static void init_warm_resume(struct sbi_scratch *scratch)
 static void __noreturn init_warmboot(struct sbi_scratch *scratch, u32 hartid)
 {
 	int hstate;
+	int rc;
 
 	wait_for_coldboot(scratch, hartid);
+
+	rc = sbi_hsm_init(scratch, hartid, FALSE);
+	if (rc)
+		sbi_hart_hang();
 
 	hstate = sbi_hsm_hart_get_state(sbi_domain_thishart_ptr(), hartid);
 	if (hstate < 0)


### PR DESCRIPTION
Move sbi_hsm_init before the usage to avoid reading unallocated memory.

In the init_warmboot() the sbi_hsm_hart_get_state() call reads hart state from hsm data, which is not yet initialized. If memory happens to have value zero, the code works, but in case data is negative (like 0xdeadbeef), the (hstate < 0) check fails and enters to hart_hang().

By moving the hsm_init() call earlier, this can be avoided.
