### PR TITLE
shrink opensbi: limit SBI_HARTMASK_MAX_BITS to 5

### DIFF
--- a/include/sbi/sbi_hartmask.h
+++ b/include/sbi/sbi_hartmask.h
@@ -19,7 +19,7 @@
  * also represents the maximum number of HART ids generic OpenSBI
  * can handle.
  */
-#define SBI_HARTMASK_MAX_BITS		128
+#define SBI_HARTMASK_MAX_BITS		5
 
 /** Representation of hartmask */
 struct sbi_hartmask {


### PR DESCRIPTION
No need to support 128 harts for now. Limiting it to 5 shrinks the size almost 2kB.