### PR TITLE
sbi_console: Remove inline from sbi_print_empty

### DIFF
--- a/include/sbi/sbi_console.h
+++ b/include/sbi/sbi_console.h
@@ -64,7 +64,7 @@ int sbi_console_init(struct sbi_scratch *scratch);
 
 #else
 #include <sbi/sbi_hart.h>
-inline int sbi_print_empty(const char *fmt, ...) { return 0; }
+int sbi_print_empty(const char *fmt, ...);
 inline void sbi_panic_noprint(const char *fmt, ...) { sbi_hart_hang(); }
 #define sbi_isprintable(ch) false
 #define sbi_getc() 0

--- a/lib/sbi/sbi_console.c
+++ b/lib/sbi/sbi_console.c
@@ -490,4 +490,9 @@ int sbi_console_init(struct sbi_scratch *scratch)
 
 	return rc;
 }
+#else
+int sbi_print_empty(const char *fmt, ...)
+{
+	return 0;
+}
 #endif


### PR DESCRIPTION
Inlining breaks compilation with "-g" flags for an unknown reason